### PR TITLE
return retry() on error (fixes firefox-crash)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function () {
         if (!ucode) ucode = createURL();
         
         try { var worker = new SharedWorker(ucode) }
-        catch (err) { setTimeout(retry, Math.min(++times * 100, 500)) }
+        catch (err) { return setTimeout(retry, Math.min(++times * 100, 500)) }
         
         var to = setTimeout(ontimeout, Math.min(++times * 100, 500));
         worker.port.addEventListener('message', onmessage);


### PR DESCRIPTION
in firefox `worker` is `undefined` when an error occurs, so it throws in line 16 in index.js

i guess this is how it was supposed anyway? unless i'm mistaken